### PR TITLE
Add least-privilege permissions to build job in CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,6 +45,8 @@ jobs:
   build:
     name: Build
     needs: test
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/lawliet89/telegram-dice-maestro-oxide/security/code-scanning/2](https://github.com/lawliet89/telegram-dice-maestro-oxide/security/code-scanning/2)

Add an explicit `permissions` block to the `build` job in `.github/workflows/build.yaml` so the `GITHUB_TOKEN` is least-privileged.  
Best minimal fix: set `contents: read` for the `build` job, matching common read-only needs for source/artifact metadata access while avoiding unnecessary write scope.

Edit region: in `.github/workflows/build.yaml`, inside `jobs.build`, add:

```yaml
permissions:
  contents: read
```

Place it alongside other job-level keys (e.g., after `needs` and before `strategy` is a clean location). No imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
